### PR TITLE
Bump Spock version to 2.4-M4

### DIFF
--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -18,7 +18,7 @@
     <groovy.4.version>4.0.17</groovy.4.version>
     <groovy.5.version>5.0.0-alpha-8</groovy.5.version>
     <groovy.version>${groovy.3.version}</groovy.version>
-    <spock.version.major>2.3</spock.version.major>
+    <spock.version.major>2.4-M4</spock.version.major>
     <spock.version.groovyVariant>3.0</spock.version.groovyVariant>
     <spock.version>${spock.version.major}-groovy-${spock.version.groovyVariant}</spock.version>
     <junit.version>5.11.3</junit.version>


### PR DESCRIPTION
Fixes issues, where Spock samples in documentation does not run.