### PR TITLE
Add the error happened while loading remote code

### DIFF
--- a/services/frontend/src/ts/view.ts
+++ b/services/frontend/src/ts/view.ts
@@ -290,7 +290,7 @@ export function initView () {
       console.log('Could not load script', err)
       executionResult = {
         out: '',
-        err: 'An error occurred while loading the remote script.\nThis can be caused by the NoScript browser extension.',
+        err: 'An error occurred while loading the remote script.\nThis can be caused by the NoScript browser extension.\n\n' + err,
         result: null,
         info: null
       }


### PR DESCRIPTION
Without this for example the stackoverflow error "maybe code is not highlighted properly" is swallowed and only shown in JS console,
while in the error tab it only says "maybe the NoScript extension is causing problems".
Now the error is also displayed.

