### PR TITLE
Update runtimes to Java 21 and nodejs22 ...

### DIFF
--- a/.github/workflows/build-github-access.yml
+++ b/.github/workflows/build-github-access.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
           cache: 'maven'
       - name: test
         run: |

--- a/.github/workflows/build-groovy-executor.yml
+++ b/.github/workflows/build-groovy-executor.yml
@@ -20,14 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variant: ['groovy_3_0', 'groovy_2_5', 'groovy_4_0', 'groovy_5_0_alpha']
+        include:
+          - variant: 'groovy_3_0'
+            java: 17
+          - variant: 'groovy_4_0'
+            java: 21
+          - variant: 'groovy_5_0_alpha'
+            java: 21
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up JDK'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: test
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: 'Set up JDK'
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 21
+        cache: 'maven'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/deploy-function-list_runtimes.yml
+++ b/.github/workflows/deploy-function-list_runtimes.yml
@@ -15,4 +15,4 @@ jobs:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
-      - run: gcloud functions deploy list_runtimes --entry-point listRuntimes --trigger-http --runtime nodejs14 --allow-unauthenticated --memory 8192MB --region europe-west1 --source functions/list_runtimes --service-account list-function-groovy-runtimes@gwc-experiment.iam.gserviceaccount.com
+      - run: gcloud functions deploy list_runtimes --entry-point listRuntimes --trigger-http --runtime nodejs22 --allow-unauthenticated --memory 8192MB --region europe-west1 --source functions/list_runtimes --service-account list-function-groovy-runtimes@gwc-experiment.iam.gserviceaccount.com

--- a/.github/workflows/deploy-github-access.yml
+++ b/.github/workflows/deploy-github-access.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
           cache: 'maven'
       - name: build jar
         run: |

--- a/.github/workflows/deploy-groovy-executor.yml
+++ b/.github/workflows/deploy-groovy-executor.yml
@@ -9,14 +9,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - variant: 'groovy_2_5'
-            java: 11
           - variant: 'groovy_3_0'
             java: 17
           - variant: 'groovy_4_0'
-            java: 17
+            java: 21
           - variant: 'groovy_5_0_alpha'
-            java: 17
+            java: 21
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up JDK'

--- a/functions/github-access/pom.xml
+++ b/functions/github-access/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>${groovy.4.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/functions/groovy-executor/pom.xml
+++ b/functions/groovy-executor/pom.xml
@@ -21,9 +21,6 @@
   <profiles>
     <profile>
       <id>groovy_3_0</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <groovy.version>${groovy.3.version}</groovy.version>
         <spock.version.groovyVariant>3.0</spock.version.groovyVariant>
@@ -59,6 +56,9 @@
     </profile>
     <profile>
       <id>groovy_4_0</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <groovy.version>${groovy.4.version}</groovy.version>
         <spock.version.groovyVariant>4.0</spock.version.groovyVariant>

--- a/functions/groovy-executor/pom.xml
+++ b/functions/groovy-executor/pom.xml
@@ -27,39 +27,8 @@
       <properties>
         <groovy.version>${groovy.3.version}</groovy.version>
         <spock.version.groovyVariant>3.0</spock.version.groovyVariant>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-bom</artifactId>
-            <version>${groovy.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-          <version>${groovy.version}</version>
-          <type>pom</type>
-          <exclusions>
-            <exclusion>
-              <groupId>org.codehaus.groovy</groupId>
-              <artifactId>groovy-test-testng</artifactId>
-              <!-- Exclude testng for now, as this causes surefire to ignore junit5 platform tests -->
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>groovy_2_5</id>
-      <properties>
-        <groovy.version>${groovy.2.version}</groovy.version>
-        <spock.version.groovyVariant>2.5</spock.version.groovyVariant>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
       </properties>
       <dependencyManagement>
         <dependencies>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -10,10 +10,9 @@
   <packaging>pom</packaging>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <groovy.2.version>2.5.23</groovy.2.version>
     <groovy.3.version>3.0.24</groovy.3.version>
     <groovy.4.version>4.0.26</groovy.4.version>
     <groovy.5.version>5.0.0-alpha-12</groovy.5.version>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -16,9 +16,9 @@
     <groovy.3.version>3.0.24</groovy.3.version>
     <groovy.4.version>4.0.26</groovy.4.version>
     <groovy.5.version>5.0.0-alpha-12</groovy.5.version>
-    <groovy.version>${groovy.3.version}</groovy.version>
+    <groovy.version>${groovy.4.version}</groovy.version>
     <spock.version.major>2.3</spock.version.major>
-    <spock.version.groovyVariant>3.0</spock.version.groovyVariant>
+    <spock.version.groovyVariant>4.0</spock.version.groovyVariant>
     <spock.version>${spock.version.major}-groovy-${spock.version.groovyVariant}</spock.version>
     <junit.version>5.12.1</junit.version>
     <functionTargetClass>gwc.GFunctionExecutor</functionTargetClass>


### PR DESCRIPTION
Remove groovy_2.5 from deployment as the Java 11 runtime is eol and can't be deployed anymore.
