### PR TITLE
Modernize Renovate config and pin Groovy via versionCompatibility

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,28 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "security:minimumReleaseAgeNpm"
   ],
   "packageRules": [
     // Disable major version upgrades for Groovy versions
     // as we want to keep one for each major version.
     {
-      matchPackagePrefixes: ["org.codehaus.groovy:"],
+      matchPackageNames: ["org.codehaus.groovy:**"],
       matchCurrentValue: "/^2\\./",
       allowedVersions: "(,3.0)"
     },
     {
-      matchPackagePrefixes: ["org.codehaus.groovy:"],
+      matchPackageNames: ["org.codehaus.groovy:**"],
       matchCurrentValue: "/^3\\./",
       allowedVersions: "(,4.0)"
     },
     {
-      matchPackagePrefixes: ["org.apache.groovy:"],
+      matchPackageNames: ["org.apache.groovy:**"],
       matchCurrentValue: "/^4\\./",
       allowedVersions: "(,5.0)"
     },
     {
-      matchPackagePrefixes: ["org.apache.groovy:"],
+      matchPackageNames: ["org.apache.groovy:**"],
       matchCurrentValue: "/^5\\./",
       allowedVersions: "(,6.0)"
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,27 +5,13 @@
     "security:minimumReleaseAgeNpm"
   ],
   "packageRules": [
-    // Disable major version upgrades for Groovy versions
-    // as we want to keep one for each major version.
+    // Pin Groovy upgrades to the same major version (we keep one entry per major).
+    // versionCompatibility extracts the major as the compatibility marker so Renovate
+    // only proposes updates within the same major, regardless of groupId migration
+    // (org.codehaus.groovy -> org.apache.groovy at 4.x).
     {
-      matchPackageNames: ["org.codehaus.groovy:**"],
-      matchCurrentValue: "/^2\\./",
-      allowedVersions: "(,3.0)"
-    },
-    {
-      matchPackageNames: ["org.codehaus.groovy:**"],
-      matchCurrentValue: "/^3\\./",
-      allowedVersions: "(,4.0)"
-    },
-    {
-      matchPackageNames: ["org.apache.groovy:**"],
-      matchCurrentValue: "/^4\\./",
-      allowedVersions: "(,5.0)"
-    },
-    {
-      matchPackageNames: ["org.apache.groovy:**"],
-      matchCurrentValue: "/^5\\./",
-      allowedVersions: "(,6.0)"
+      matchPackageNames: ["org.codehaus.groovy:**", "org.apache.groovy:**"],
+      versionCompatibility: "^(?<compatibility>\\d+)\\.(?<version>.+)$"
     },
     // Automerge non-major updates https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates
     {


### PR DESCRIPTION
## Summary
- Add `security:minimumReleaseAgeNpm` preset to mitigate npm supply-chain risk (3-day minimum release age for npm packages).
- Migrate deprecated config: `config:base` → `config:recommended`, and `matchPackagePrefixes` → `matchPackageNames` with `**` glob syntax.
- Replace the four per-major Groovy pinning rules with a single rule using `versionCompatibility` — the major version becomes the compatibility marker, so Renovate only proposes within-major updates for both `org.codehaus.groovy:**` and `org.apache.groovy:**`.
