### PR TITLE
feat: add spinner to execute buttons

### DIFF
--- a/services/frontend/src/templates/index.html
+++ b/services/frontend/src/templates/index.html
@@ -128,7 +128,11 @@
                     </div>
                 </div>
                 <button id="execute" class="flex items-center gap-1 md:gap-2 px-3 md:px-6 py-2 bg-primary-container text-on-primary-container hover:opacity-90 transition-all font-label-caps text-label-caps rounded-lg shadow-sm">
-                    <span class="material-symbols-outlined text-[18px]" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
+                    <span class="material-symbols-outlined text-[18px] play-icon" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
+                    <svg class="animate-spin h-[18px] w-[18px] text-current hidden spinner-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
                     <span class="hidden md:inline">Execute</span>
                 </button>
             </div>
@@ -242,7 +246,11 @@
 <!-- Floating Action for Mobile -->
 <div class="md:hidden fixed bottom-6 right-6 z-50">
     <button id="executeMobile" class="w-14 h-14 rounded-full bg-primary-container text-on-primary-container flex items-center justify-center shadow-lg active:scale-95 transition-transform" onclick="document.getElementById('execute').click()">
-        <span class="material-symbols-outlined text-2xl" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
+        <span class="material-symbols-outlined text-2xl play-icon" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
+        <svg class="animate-spin h-7 w-7 text-current hidden spinner-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
     </button>
 </div>
 

--- a/services/frontend/src/ts/view.ts
+++ b/services/frontend/src/ts/view.ts
@@ -97,12 +97,40 @@ function addTabBehavior (tab: HTMLElement) {
     ).subscribe(() => updateOutput())
 }
 
+function setLoadingState (target: HTMLElement, loading: boolean) {
+  if (loading) {
+    target.classList.add('opacity-50', 'pointer-events-none')
+  } else {
+    target.classList.remove('opacity-50', 'pointer-events-none')
+  }
+
+  const playIcon = target.querySelector('.play-icon')
+  const spinnerIcon = target.querySelector('.spinner-icon')
+
+  if (playIcon && spinnerIcon) {
+    if (loading) {
+      playIcon.classList.add('hidden')
+      spinnerIcon.classList.remove('hidden')
+    } else {
+      playIcon.classList.remove('hidden')
+      spinnerIcon.classList.add('hidden')
+    }
+  }
+
+  if (target.id === 'execute') {
+    const mobileBtn = document.getElementById('executeMobile')
+    if (mobileBtn && mobileBtn !== target) {
+      setLoadingState(mobileBtn, loading)
+    }
+  }
+}
+
 function scriptExecution (target: HTMLElement, action: () => Observable<ExecutionResult>) {
   fromEvent(target, 'click')
     .pipe(
       throttleTime(500),
       tap(() => {
-        target.classList.add('opacity-50', 'pointer-events-none')
+        setLoadingState(target, true)
         clearOutput()
       }),
       concatMap(action),
@@ -111,12 +139,12 @@ function scriptExecution (target: HTMLElement, action: () => Observable<Executio
     .subscribe({
       next: result => {
         executionResult = result
-        target.classList.remove('opacity-50', 'pointer-events-none')
+        setLoadingState(target, false)
         updateOutput()
       },
       error: err => {
         console.log('Response NOT OK', err)
-        target.classList.remove('opacity-50', 'pointer-events-none')
+        setLoadingState(target, false)
         executionResult = {
           out: '',
           err: 'An error occurred while sending the Groovy script for execution',

--- a/services/frontend/src/ts/view.ts
+++ b/services/frontend/src/ts/view.ts
@@ -100,8 +100,18 @@ function addTabBehavior (tab: HTMLElement) {
 function setLoadingState (target: HTMLElement, loading: boolean) {
   if (loading) {
     target.classList.add('opacity-50', 'pointer-events-none')
+    target.setAttribute('aria-busy', 'true')
+    target.setAttribute('aria-disabled', 'true')
+    if (target instanceof HTMLButtonElement) {
+      target.disabled = true
+    }
   } else {
     target.classList.remove('opacity-50', 'pointer-events-none')
+    target.removeAttribute('aria-busy')
+    target.removeAttribute('aria-disabled')
+    if (target instanceof HTMLButtonElement) {
+      target.disabled = false
+    }
   }
 
   const playIcon = target.querySelector('.play-icon')


### PR DESCRIPTION
Restores the loading spinner effect on the Execute button (and mobile FAB) while a Groovy script is running. Ensures the UI correctly signals background execution.