### PR TITLE
feat: add Groovy 6 syntax highlighting support

### DIFF
--- a/services/frontend/cypress/e2e/syntax-highlighting.cy.ts
+++ b/services/frontend/cypress/e2e/syntax-highlighting.cy.ts
@@ -1,0 +1,78 @@
+import { interceptIndefinitely } from '../support/utils'
+
+describe('syntax highlighting', () => {
+  beforeEach(() => {
+    cy.stubListRuntimes()
+    cy.visit('/')
+    cy.wait(['@list_runtimes', '@warmup_request'])
+  })
+
+  it('highlights val and var like def', () => {
+    cy.setCodeEditorValue('def a = 1\nval b = 2\nvar c = 3')
+    
+    cy.get('#code .cm-content').within(() => {
+      cy.get('.cm-line').eq(0).contains('span', 'def').invoke('attr', 'class').then(keywordClass => {
+        cy.get('.cm-line').eq(1).contains('span', 'val').should('have.attr', 'class', keywordClass)
+        cy.get('.cm-line').eq(2).contains('span', 'var').should('have.attr', 'class', keywordClass)
+      })
+    })
+  })
+
+  it('highlights async, await, defer as keywords', () => {
+    cy.setCodeEditorValue('def a\nasync b\nawait c\ndefer d')
+    
+    cy.get('#code .cm-content').within(() => {
+      cy.get('.cm-line').eq(0).contains('span', 'def').invoke('attr', 'class').then(keywordClass => {
+        cy.get('.cm-line').eq(1).contains('span', 'async').should('have.attr', 'class', keywordClass)
+        cy.get('.cm-line').eq(2).contains('span', 'await').should('have.attr', 'class', keywordClass)
+        cy.get('.cm-line').eq(3).contains('span', 'defer').should('have.attr', 'class', keywordClass)
+      })
+    })
+  })
+
+  it('highlights yield contextually', () => {
+    cy.setCodeEditorValue('return a\nyield return b\nyield c')
+    
+    cy.get('#code .cm-content').within(() => {
+      cy.get('.cm-line').eq(0).contains('span', 'return').invoke('attr', 'class').then(returnClass => {
+        // 'yield' on line 2 should have the keyword class
+        cy.get('.cm-line').eq(1).contains('span', 'yield').should('have.attr', 'class', returnClass)
+        
+        // 'yield' on line 3 should not have the keyword class
+        cy.get('.cm-line').eq(2).then($line => {
+          const spans = $line.find('span')
+          const yieldSpan = Array.from(spans).find(s => s.innerText === 'yield')
+          if (yieldSpan) {
+            expect(yieldSpan.className).not.to.eq(returnClass)
+          } else {
+            // Unstyled text means it correctly wasn't treated as a keyword
+            expect(true).to.be.true
+          }
+        })
+      })
+    })
+  })
+
+  it('highlights module contextually', () => {
+    cy.setCodeEditorValue('import a\nimport module b\nmodule c')
+    
+    cy.get('#code .cm-content').within(() => {
+      cy.get('.cm-line').eq(0).contains('span', 'import').invoke('attr', 'class').then(importClass => {
+        // 'module' on line 2 should have the keyword class
+        cy.get('.cm-line').eq(1).contains('span', 'module').should('have.attr', 'class', importClass)
+        
+        // 'module' on line 3 should not have the keyword class
+        cy.get('.cm-line').eq(2).then($line => {
+          const spans = $line.find('span')
+          const moduleSpan = Array.from(spans).find(s => s.innerText === 'module')
+          if (moduleSpan) {
+            expect(moduleSpan.className).not.to.eq(importClass)
+          } else {
+            // Unstyled text
+            expect(true).to.be.true
+          }
+        })
+      })
+    })
+  })
+})

--- a/services/frontend/cypress/e2e/syntax-highlighting.cy.ts
+++ b/services/frontend/cypress/e2e/syntax-highlighting.cy.ts
@@ -1,5 +1,3 @@
-import { interceptIndefinitely } from '../support/utils'
-
 describe('syntax highlighting', () => {
   beforeEach(() => {
     cy.stubListRuntimes()
@@ -9,7 +7,7 @@ describe('syntax highlighting', () => {
 
   it('highlights val and var like def', () => {
     cy.setCodeEditorValue('def a = 1\nval b = 2\nvar c = 3')
-    
+
     cy.get('#code .cm-content').within(() => {
       cy.get('.cm-line').eq(0).contains('span', 'def').invoke('attr', 'class').then(keywordClass => {
         cy.get('.cm-line').eq(1).contains('span', 'val').should('have.attr', 'class', keywordClass)
@@ -20,7 +18,7 @@ describe('syntax highlighting', () => {
 
   it('highlights async, await, defer as keywords', () => {
     cy.setCodeEditorValue('def a\nasync b\nawait c\ndefer d')
-    
+
     cy.get('#code .cm-content').within(() => {
       cy.get('.cm-line').eq(0).contains('span', 'def').invoke('attr', 'class').then(keywordClass => {
         cy.get('.cm-line').eq(1).contains('span', 'async').should('have.attr', 'class', keywordClass)
@@ -32,12 +30,12 @@ describe('syntax highlighting', () => {
 
   it('highlights yield contextually', () => {
     cy.setCodeEditorValue('return a\nyield return b\nyield c')
-    
+
     cy.get('#code .cm-content').within(() => {
       cy.get('.cm-line').eq(0).contains('span', 'return').invoke('attr', 'class').then(returnClass => {
         // 'yield' on line 2 should have the keyword class
         cy.get('.cm-line').eq(1).contains('span', 'yield').should('have.attr', 'class', returnClass)
-        
+
         // 'yield' on line 3 should not have the keyword class
         cy.get('.cm-line').eq(2).then($line => {
           const spans = $line.find('span')
@@ -46,7 +44,7 @@ describe('syntax highlighting', () => {
             expect(yieldSpan.className).not.to.eq(returnClass)
           } else {
             // Unstyled text means it correctly wasn't treated as a keyword
-            expect(true).to.be.true
+            expect(true).to.equal(true)
           }
         })
       })
@@ -55,12 +53,12 @@ describe('syntax highlighting', () => {
 
   it('highlights module contextually', () => {
     cy.setCodeEditorValue('import a\nimport module b\nmodule c')
-    
+
     cy.get('#code .cm-content').within(() => {
       cy.get('.cm-line').eq(0).contains('span', 'import').invoke('attr', 'class').then(importClass => {
         // 'module' on line 2 should have the keyword class
         cy.get('.cm-line').eq(1).contains('span', 'module').should('have.attr', 'class', importClass)
-        
+
         // 'module' on line 3 should not have the keyword class
         cy.get('.cm-line').eq(2).then($line => {
           const spans = $line.find('span')
@@ -69,7 +67,7 @@ describe('syntax highlighting', () => {
             expect(moduleSpan.className).not.to.eq(importClass)
           } else {
             // Unstyled text
-            expect(true).to.be.true
+            expect(true).to.equal(true)
           }
         })
       })

--- a/services/frontend/src/ts/codemirror.ts
+++ b/services/frontend/src/ts/codemirror.ts
@@ -36,7 +36,7 @@ import {
   StreamLanguage,
   syntaxHighlighting
 } from '@codemirror/language'
-import { groovy } from '@codemirror/legacy-modes/mode/groovy'
+import { groovy } from './groovy-mode'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { highlightSelectionMatches, searchKeymap } from '@codemirror/search'
 import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'

--- a/services/frontend/src/ts/groovy-mode.ts
+++ b/services/frontend/src/ts/groovy-mode.ts
@@ -1,0 +1,242 @@
+/* eslint-disable */
+// @ts-nocheck
+function words(str) {
+  var obj = {}, words = str.split(" ");
+  for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
+  return obj;
+}
+var keywords = words(
+  "abstract as assert boolean break byte case catch char class const continue def default " +
+    "do double else enum extends final finally float for goto if implements import in " +
+    "instanceof int interface long native new package private protected public return " +
+    "short static strictfp super switch synchronized threadsafe throw throws trait transient " +
+    "try void volatile while val var async await defer");
+var blockKeywords = words("catch class def do else enum finally for if interface switch trait try while val var");
+var standaloneKeywords = words("return break continue");
+var atoms = words("null true false this");
+
+var curPunc;
+function tokenBase(stream, state) {
+  var ch = stream.next();
+  if (ch == '"' || ch == "'") {
+    return startString(ch, stream, state);
+  }
+  if (/[\[\]{}\(\),;\:\.]/.test(ch)) {
+    curPunc = ch;
+    return null;
+  }
+  if (/\d/.test(ch)) {
+    stream.eatWhile(/[\w\.]/);
+    if (stream.eat(/eE/)) { stream.eat(/\+\-/); stream.eatWhile(/\d/); }
+    return "number";
+  }
+  if (ch == "/") {
+    if (stream.eat("*")) {
+      state.tokenize.push(tokenComment);
+      return tokenComment(stream, state);
+    }
+    if (stream.eat("/")) {
+      stream.skipToEnd();
+      return "comment";
+    }
+    if (expectExpression(state.lastToken, false)) {
+      return startString(ch, stream, state);
+    }
+  }
+  if (ch == "-" && stream.eat(">")) {
+    curPunc = "->";
+    return null;
+  }
+  if (/[+\-*&%=<>!?|\/~]/.test(ch)) {
+    stream.eatWhile(/[+\-*&%=<>|~]/);
+    return "operator";
+  }
+  stream.eatWhile(/[\w\$_]/);
+  if (ch == "@") { stream.eatWhile(/[\w\$_\.]/); return "meta"; }
+  if (state.lastToken == ".") return "property";
+  if (stream.eat(":")) { curPunc = "proplabel"; return "property"; }
+  var cur = stream.current();
+
+  if (cur === "module" && state.lastWord === "import") {
+    state.lastWord = cur;
+    return "keyword";
+  }
+  if (cur === "yield" && stream.match(/^\s*return/, false)) {
+    curPunc = "standalone";
+    state.lastWord = cur;
+    return "keyword";
+  }
+
+  if (atoms.propertyIsEnumerable(cur)) { state.lastWord = cur; return "atom"; }
+  if (keywords.propertyIsEnumerable(cur)) {
+    if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
+    else if (standaloneKeywords.propertyIsEnumerable(cur)) curPunc = "standalone";
+    state.lastWord = cur;
+    return "keyword";
+  }
+  state.lastWord = cur;
+  return "variable";
+}
+tokenBase.isBase = true;
+
+function startString(quote, stream, state) {
+  var tripleQuoted = false;
+  if (quote != "/" && stream.eat(quote)) {
+    if (stream.eat(quote)) tripleQuoted = true;
+    else return "string";
+  }
+  function t(stream, state) {
+    var escaped = false, next, end = !tripleQuoted;
+    while ((next = stream.next()) != null) {
+      if (next == quote && !escaped) {
+        if (!tripleQuoted) { break; }
+        if (stream.match(quote + quote)) { end = true; break; }
+      }
+      if (quote == '"' && next == "$" && !escaped) {
+        if (stream.eat("{")) {
+          state.tokenize.push(tokenBaseUntilBrace());
+          return "string";
+        } else if (stream.match(/^\w/, false)) {
+          state.tokenize.push(tokenVariableDeref);
+          return "string";
+        }
+      }
+      escaped = !escaped && next == "\\";
+    }
+    if (end) state.tokenize.pop();
+    return "string";
+  }
+  state.tokenize.push(t);
+  return t(stream, state);
+}
+
+function tokenBaseUntilBrace() {
+  var depth = 1;
+  function t(stream, state) {
+    if (stream.peek() == "}") {
+      depth--;
+      if (depth == 0) {
+        state.tokenize.pop();
+        return state.tokenize[state.tokenize.length-1](stream, state);
+      }
+    } else if (stream.peek() == "{") {
+      depth++;
+    }
+    return tokenBase(stream, state);
+  }
+  t.isBase = true;
+  return t;
+}
+
+function tokenVariableDeref(stream, state) {
+  var next = stream.match(/^(\.|[\w\$_]+)/)
+  if (!next || !stream.match(next[0] == "." ? /^[\w$_]/ : /^\./)) state.tokenize.pop()
+  if (!next) return state.tokenize[state.tokenize.length-1](stream, state)
+  return next[0] == "." ? null : "variable"
+}
+
+function tokenComment(stream, state) {
+  var maybeEnd = false, ch;
+  while (ch = stream.next()) {
+    if (ch == "/" && maybeEnd) {
+      state.tokenize.pop();
+      break;
+    }
+    maybeEnd = (ch == "*");
+  }
+  return "comment";
+}
+
+function expectExpression(last, newline) {
+  return !last || last == "operator" || last == "->" || /[\.\[\{\(,;:]/.test(last) ||
+    last == "newstatement" || last == "keyword" || last == "proplabel" ||
+    (last == "standalone" && !newline);
+}
+
+function Context(indented, column, type, align, prev) {
+  this.indented = indented;
+  this.column = column;
+  this.type = type;
+  this.align = align;
+  this.prev = prev;
+}
+function pushContext(state, col, type) {
+  return state.context = new Context(state.indented, col, type, null, state.context);
+}
+function popContext(state) {
+  var t = state.context.type;
+  if (t == ")" || t == "]" || t == "}")
+    state.indented = state.context.indented;
+  return state.context = state.context.prev;
+}
+
+// Interface
+
+export const groovy = {
+  name: "groovy",
+  startState: function(indentUnit) {
+    return {
+      tokenize: [tokenBase],
+      context: new Context(-indentUnit, 0, "top", false),
+      indented: 0,
+      startOfLine: true,
+      lastToken: null,
+      lastWord: null
+    };
+  },
+
+  token: function(stream, state) {
+    var ctx = state.context;
+    if (stream.sol()) {
+      if (ctx.align == null) ctx.align = false;
+      state.indented = stream.indentation();
+      state.startOfLine = true;
+      // Automatic semicolon insertion
+      if (ctx.type == "statement" && !expectExpression(state.lastToken, true)) {
+        popContext(state); ctx = state.context;
+      }
+    }
+    if (stream.eatSpace()) return null;
+    curPunc = null;
+    var style = state.tokenize[state.tokenize.length-1](stream, state);
+    if (style == "comment") return style;
+    if (ctx.align == null) ctx.align = true;
+
+    if ((curPunc == ";" || curPunc == ":") && ctx.type == "statement") popContext(state);
+    // Handle indentation for {x -> \n ... }
+    else if (curPunc == "->" && ctx.type == "statement" && ctx.prev.type == "}") {
+      popContext(state);
+      state.context.align = false;
+    }
+    else if (curPunc == "{") pushContext(state, stream.column(), "}");
+    else if (curPunc == "[") pushContext(state, stream.column(), "]");
+    else if (curPunc == "(") pushContext(state, stream.column(), ")");
+    else if (curPunc == "}") {
+      while (ctx.type == "statement") ctx = popContext(state);
+      if (ctx.type == "}") ctx = popContext(state);
+      while (ctx.type == "statement") ctx = popContext(state);
+    }
+    else if (curPunc == ctx.type) popContext(state);
+    else if (ctx.type == "}" || ctx.type == "top" || (ctx.type == "statement" && curPunc == "newstatement"))
+      pushContext(state, stream.column(), "statement");
+    state.startOfLine = false;
+    state.lastToken = curPunc || style;
+    return style;
+  },
+
+  indent: function(state, textAfter, cx) {
+    if (!state.tokenize[state.tokenize.length-1].isBase) return null;
+    var firstChar = textAfter && textAfter.charAt(0), ctx = state.context;
+    if (ctx.type == "statement" && !expectExpression(state.lastToken, true)) ctx = ctx.prev;
+    var closing = firstChar == ctx.type;
+    if (ctx.type == "statement") return ctx.indented + (firstChar == "{" ? 0 : cx.unit);
+    else if (ctx.align) return ctx.column + (closing ? 0 : 1);
+    else return ctx.indented + (closing ? 0 : cx.unit);
+  },
+
+  languageData: {
+    indentOnInput: /^\s*[{}]$/,
+    commentTokens: {line: "//", block: {open: "/*", close: "*/"}},
+    closeBrackets: {brackets: ["(", "[", "{", "'", '"', "'''", '"""']}
+  }
+};

--- a/services/frontend/src/ts/groovy-mode.ts
+++ b/services/frontend/src/ts/groovy-mode.ts
@@ -26,8 +26,8 @@ function tokenBase(stream, state) {
     return null;
   }
   if (/\d/.test(ch)) {
-    stream.eatWhile(/[\w\.]/);
-    if (stream.eat(/eE/)) { stream.eat(/\+\-/); stream.eatWhile(/\d/); }
+    stream.eatWhile(/[\d\.]/);
+    if (stream.eat(/[eE]/)) { stream.eat(/[+\-]/); stream.eatWhile(/\d/); }
     return "number";
   }
   if (ch == "/") {
@@ -92,7 +92,7 @@ function startString(quote, stream, state) {
         if (!tripleQuoted) { break; }
         if (stream.match(quote + quote)) { end = true; break; }
       }
-      if (quote == '"' && next == "$" && !escaped) {
+      if ((quote == '"' || quote == '/') && next == "$" && !escaped) {
         if (stream.eat("{")) {
           state.tokenize.push(tokenBaseUntilBrace());
           return "string";


### PR DESCRIPTION
Replaces the default legacy CodeMirror groovy parser with a custom localized version that supports the new Groovy 6.0 keywords: `val`, `var`, `async`, `await`, `defer`, `yield`, and `module`.