### PR TITLE
fix: align header button heights

### DIFF
--- a/services/frontend/src/templates/index.html
+++ b/services/frontend/src/templates/index.html
@@ -93,8 +93,8 @@
             <div class="flex items-center gap-2 shrink-0">
                 <!-- Gist Toolbar Controls -->
                 <div id="updateGistControl" class="hidden">
-                    <button id="updateGist" class="flex items-center gap-1 md:gap-2 px-3 md:px-4 py-2 bg-[#00a896] text-white hover:opacity-90 transition-all font-label-caps text-label-caps rounded-lg shadow-sm">
-                        <i class="fas fa-save text-[16px]"></i>
+                    <button id="updateGist" class="flex items-center gap-1 md:gap-2 px-3 md:px-4 py-2 border border-transparent bg-[#00a896] text-white hover:opacity-90 transition-all font-label-caps text-label-caps rounded-lg shadow-sm">
+                        <i class="fas fa-save text-[18px]"></i>
                         <span class="hidden md:inline">Update gist</span>
                     </button>
                 </div>
@@ -127,7 +127,7 @@
                         </div>
                     </div>
                 </div>
-                <button id="execute" class="flex items-center gap-1 md:gap-2 px-3 md:px-6 py-2 bg-primary-container text-on-primary-container hover:opacity-90 transition-all font-label-caps text-label-caps rounded-lg shadow-sm">
+                <button id="execute" class="flex items-center gap-1 md:gap-2 px-3 md:px-6 py-2 border border-transparent bg-primary-container text-on-primary-container hover:opacity-90 transition-all font-label-caps text-label-caps rounded-lg shadow-sm">
                     <span class="material-symbols-outlined text-[18px] play-icon" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
                     <svg class="animate-spin h-[18px] w-[18px] text-current hidden spinner-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>


### PR DESCRIPTION
Matches the `updateGist` and `execute` button heights to the `shareAsCode` button by standardizing icon sizes to 18px and adding transparent borders.