### PR TITLE
feat: upgrade Groovy 6 runtime to 6.0.0-RC-1

### DIFF
--- a/.github/workflows/build-groovy-executor.yml
+++ b/.github/workflows/build-groovy-executor.yml
@@ -27,7 +27,7 @@ jobs:
             java: 21
           - variant: 'groovy_5_0'
             java: 21
-          - variant: 'groovy_6_0_alpha'
+          - variant: 'groovy_6_0_rc'
             java: 21
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy-groovy-executor.yml
+++ b/.github/workflows/deploy-groovy-executor.yml
@@ -15,7 +15,7 @@ jobs:
             java: 21
           - variant: 'groovy_5_0'
             java: 21
-          - variant: 'groovy_6_0_alpha'
+          - variant: 'groovy_6_0_rc'
             java: 21
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The output will be in `functions/groovy-executor/target/deployment`.
 
 There are different profiles, one for each groovy version:
 
-* `groovy_6_0_alpha` (no Spock — see below)
+* `groovy_6_0_rc` (no Spock — see below)
 * `groovy_5_0`
 * `groovy_4_0` (default)
 * `groovy_3_0`
@@ -38,21 +38,21 @@ There are different profiles, one for each groovy version:
 Use `../../mvnw package -P groovy_5_0`
 
 > **Switching profiles locally requires `clean`.** Each profile compiles a
-> different set of (test) sources, so run e.g. `../../mvnw clean package -P groovy_6_0_alpha`.
+> different set of (test) sources, so run e.g. `../../mvnw clean package -P groovy_6_0_rc`.
 > Without `clean`, stale classes from a previous profile linger in `target/` and
 > can cause a confusing `spock/lang/Specification` failure when building the
-> Spock-free `groovy_6_0_alpha` variant. (CI is unaffected — it builds from a
+> Spock-free `groovy_6_0_rc` variant. (CI is unaffected — it builds from a
 > fresh checkout.)
 
 #### Groovy 6 (pre-release, no Spock)
 
-Spock has no release compatible with Groovy 6 yet, so the `groovy_6_0_alpha`
+Spock has no release compatible with Groovy 6 yet, so the `groovy_6_0_rc`
 variant ships **without** Spock. Plain Groovy scripts run normally; submitting a
 Spock specification (or using the AST view) returns a "not supported on this
-Groovy version yet" message instead. The concrete alpha version is controlled by
+Groovy version yet" message instead. The concrete RC version is controlled by
 the `groovy.6.version` property in `functions/pom.xml`, so bumping to a newer
-alpha is a one-line change deployed to the same `groovy_6_0_alpha` function.
-Because the runtime id contains `alpha`, the frontend never selects it as the
+RC is a one-line change deployed to the same `groovy_6_0_rc` function.
+Because the runtime id contains `rc`, the frontend never selects it as the
 default version.
 
 ### Deploying the backend

--- a/functions/groovy-executor/pom.xml
+++ b/functions/groovy-executor/pom.xml
@@ -277,7 +277,7 @@
       <!-- Groovy 6 is pre-release and Spock has no compatible release yet, so this
            variant ships WITHOUT spock-core. Spec/AST requests return a "not supported"
            message via the SpecSupport SPI (no provider is on the classpath). -->
-      <id>groovy_6_0_alpha</id>
+      <id>groovy_6_0_rc</id>
       <properties>
         <groovy.version>${groovy.6.version}</groovy.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -16,7 +16,7 @@
     <groovy.3.version>3.0.25</groovy.3.version>
     <groovy.4.version>4.0.31</groovy.4.version>
     <groovy.5.version>5.0.3</groovy.5.version>
-    <groovy.6.version>6.0.0-alpha-1</groovy.6.version>
+    <groovy.6.version>6.0.0-RC-1</groovy.6.version>
     <groovy.version>${groovy.4.version}</groovy.version>
     <spock.version.major>2.4</spock.version.major>
     <spock.version.groovyVariant>4.0</spock.version.groovyVariant>

--- a/services/frontend/src/ts/groovy-console.ts
+++ b/services/frontend/src/ts/groovy-console.ts
@@ -8,7 +8,7 @@ export class GroovyVersion {
 
   constructor (public id: string) {
     const rest = id.substring('groovy_'.length)
-    // e.g. "6_0_rc" -> "6.0-rc", "4_0" -> "4.0"; leave anything unexpected as-is
+    // e.g. "6_0_alpha" -> "6.0-alpha", "4_0" -> "4.0"; leave anything unexpected as-is
     const match = rest.match(/^(\d+)_(\d+)(?:_(.+))?$/)
     this.name = match
       ? `Groovy ${match[1]}.${match[2]}${match[3] ? '-' + match[3].replace(/_/g, '-') : ''}`

--- a/services/frontend/src/ts/groovy-console.ts
+++ b/services/frontend/src/ts/groovy-console.ts
@@ -8,7 +8,7 @@ export class GroovyVersion {
 
   constructor (public id: string) {
     const rest = id.substring('groovy_'.length)
-    // e.g. "6_0_alpha" -> "6.0-alpha", "4_0" -> "4.0"; leave anything unexpected as-is
+    // e.g. "6_0_rc" -> "6.0-rc", "4_0" -> "4.0"; leave anything unexpected as-is
     const match = rest.match(/^(\d+)_(\d+)(?:_(.+))?$/)
     this.name = match
       ? `Groovy ${match[1]}.${match[2]}${match[3] ? '-' + match[3].replace(/_/g, '-') : ''}`


### PR DESCRIPTION
Upgrades the Groovy 6 runtime from `6.0.0-alpha-1` to `6.0.0-RC-1`:

- Update `groovy.6.version` to `6.0.0-RC-1` in `functions/pom.xml`
- Rename Maven profile and Cloud Function executor variant from `groovy_6_0_alpha` to `groovy_6_0_rc` (so the UI dropdown displays `Groovy 6.0-rc` and future RCs can be bumped with a version property change)
- Update CI/CD build and deploy workflows (`build-groovy-executor.yml`, `deploy-groovy-executor.yml`)
- Update `README.md` and frontend comments accordingly

Fallback tests without Spock pass successfully.