### PR TITLE
feat: update Groovy 4 to 4.0.33 and Groovy 5 to 5.1.2

### DIFF
--- a/.github/workflows/build-groovy-executor.yml
+++ b/.github/workflows/build-groovy-executor.yml
@@ -25,7 +25,7 @@ jobs:
             java: 17
           - variant: 'groovy_4_0'
             java: 21
-          - variant: 'groovy_5_0'
+          - variant: 'groovy_5_1'
             java: 21
           - variant: 'groovy_6_0_rc'
             java: 21

--- a/.github/workflows/deploy-groovy-executor.yml
+++ b/.github/workflows/deploy-groovy-executor.yml
@@ -13,7 +13,7 @@ jobs:
             java: 17
           - variant: 'groovy_4_0'
             java: 21
-          - variant: 'groovy_5_0'
+          - variant: 'groovy_5_1'
             java: 21
           - variant: 'groovy_6_0_rc'
             java: 21

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The output will be in `functions/groovy-executor/target/deployment`.
 There are different profiles, one for each groovy version:
 
 * `groovy_6_0_rc` (no Spock — see below)
-* `groovy_5_0`
+* `groovy_5_1`
 * `groovy_4_0` (default)
 * `groovy_3_0`
 
-Use `../../mvnw package -P groovy_5_0`
+Use `../../mvnw package -P groovy_5_1`
 
 > **Switching profiles locally requires `clean`.** Each profile compiles a
 > different set of (test) sources, so run e.g. `../../mvnw clean package -P groovy_6_0_rc`.

--- a/functions/groovy-executor/pom.xml
+++ b/functions/groovy-executor/pom.xml
@@ -189,7 +189,7 @@
       </build>
     </profile>
     <profile>
-      <id>groovy_5_0</id>
+      <id>groovy_5_1</id>
       <properties>
         <groovy.version>${groovy.5.version}</groovy.version>
         <spock.version.groovyVariant>5.0</spock.version.groovyVariant>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -14,8 +14,8 @@
     <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <groovy.3.version>3.0.25</groovy.3.version>
-    <groovy.4.version>4.0.31</groovy.4.version>
-    <groovy.5.version>5.0.3</groovy.5.version>
+    <groovy.4.version>4.0.33</groovy.4.version>
+    <groovy.5.version>5.1.2</groovy.5.version>
     <groovy.6.version>6.0.0-RC-1</groovy.6.version>
     <groovy.version>${groovy.4.version}</groovy.version>
     <spock.version.major>2.4</spock.version.major>


### PR DESCRIPTION
Updates Groovy runtimes for Groovy 4 and Groovy 5:

- Update `groovy.4.version` from `4.0.31` to `4.0.33`
- Update `groovy.5.version` from `5.0.3` to `5.1.2`
- Rename Maven profile and Cloud Function executor variant from `groovy_5_0` to `groovy_5_1`
- Update CI/CD build and deploy workflows (`build-groovy-executor.yml`, `deploy-groovy-executor.yml`)
- Update `README.md` references to `groovy_5_1`

All test suites (including Spock specifications and AST rendering) pass successfully on both runtimes.